### PR TITLE
Fix for `indexOf` error spat out by BP build task

### DIFF
--- a/lib/voltron.js
+++ b/lib/voltron.js
@@ -56,7 +56,9 @@ function installDevDeps(voltronExtensions, directory) {
  * @return {Array<String>}
  */
 function getExtensionNames(packageJson) {
-  return Object.keys(packageJson.dependencies).filter(dep => dep.indexOf('voltron-') >= 0);
+  return Object.keys(packageJson.dependencies).filter(function(dep) {
+    dep.indexOf('voltron-') >= 0;
+  });
 }
 
 function prependExtensionNameToPath(name) {


### PR DESCRIPTION
..I have no idea why. Maybe because I use node v4.6.x?