### PR TITLE
WS-5251 make more transparent

### DIFF
--- a/lib/voltron.js
+++ b/lib/voltron.js
@@ -198,7 +198,10 @@ function updateManifest(configs, manifest) {
 function buildExtensions(configs, buildOpts) {
   return configs.reduce(function(prom, opts) {
     return prom.then(_ => opts.build(buildOpts));
-  }, Promise.resolve(true)).catch(_ => buildExtensions(configs, buildOpts));
+  }, Promise.resolve(true)).catch((e) => {
+    console.warn(`Voltron build failed. Retrying. ${e}`);
+    return buildExtensions(configs, buildOpts)
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
While troubleshooting BP nightly build, there was infinite recursion happening due to dependency issue. Having a log statement on these retries would significantly help debugging.